### PR TITLE
Add a CI that checks that all packages build correctly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: Nix 3rd party CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ensure_cluster_builds_linux:
+    runs-on: ["self-hosted", "aws_autoscaling"]
+    environment: prod
+    name: Linux CI
+    steps:
+      - name: checkout local actions
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: build
+        run: nix build -L

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,15 @@
             hashtree = hashtree;
             intx = intx;
           });
+          # The "all" package will build all packages. Convenient for CI,
+          # so that "nix build" will check that all packages are correct.
+          # The packages that have no changes will not be rebuilt, and instead
+          # fetched from the cache.
+          all = pkgs.symlinkJoin {
+            name = "all";
+            paths = [ intx hashtree sszpp ];
+          };
+          default = all;
         };
 
         overlays.default = final: prev: packages;


### PR DESCRIPTION
This patch adds a CI setup that would attempt to build all packages in this flake. Only the packages that are changed would be rebuilt because of caching.