### PR TITLE
Add patch for Hashtree library, which fixes linking warning

### DIFF
--- a/nix/hashtree/hashtree-execstack-fix.diff
+++ b/nix/hashtree/hashtree-execstack-fix.diff
@@ -1,0 +1,15 @@
+diff --git a/src/sha256_shani.S b/src/sha256_shani.S
+index 6599e02..cabc11f 100644
+--- a/src/sha256_shani.S
++++ b/src/sha256_shani.S
+@@ -973,5 +973,9 @@ hashtree_sha256_shani_x2:
+ 	movdqa		xmm15, [rsp + 9*16]
+ #endif
+ 	add		rsp, frame_size
+-	ret	
++	ret 
++#ifdef __linux__ 
++.size hashtree_sha256_shani_x2,.-hashtree_sha256_shani_x2
++.section .note.GNU-stack,"",@progbits
++#endif
+ #endif

--- a/nix/hashtree/hashtree.nix
+++ b/nix/hashtree/hashtree.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
       hash = "sha256-DHoFX8mbn4QKGj5Ch6R87swsoqXUXDweGL2KYjRVZEg=";
     };
 
+  patches = [
+    ./hashtree-execstack-fix.diff
+  ];
+
   outputs = [ "out" ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-no-integrated-as -std=c2x";


### PR DESCRIPTION
Without this GNU linker 2.39+ will produce a warning every time Hashtree is linked:

```
ld: warning: sha256_shani.o: missing .note.GNU-stack section implies executable stack
ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```